### PR TITLE
Added new setting keepLastOnHoverTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ $('input[name="country"]').amsifySuggestags({
 	showAllSuggestions: true
 });
 ```
+### keepLastOnHoverTag
+This will keep the last suggestion item in the input text field, even when moving away from the suggestion list. By default this is `true`.
+Useful when `showAllSuggestions` is set to `true` and you wish to hide the suggestion list when clicking away from the input text field.
+```js
+$('input[name="country"]').amsifySuggestags({
+	keepLastOnHoverTag: false
+});
+```
 
 ## Programmatically
 This is also one of the approach you can use this plugin.

--- a/js/jquery.amsify.suggestags.js
+++ b/js/jquery.amsify.suggestags.js
@@ -38,7 +38,8 @@ var AmsifySuggestags;
             selectOnHover     : true,
             triggerChange     : false,
             noSuggestionMsg   : '',
-            showAllSuggestions: false
+            showAllSuggestions: false,
+            keepLastOnHoverTag: true
         };
         this.method        = undefined;
         this.name          = null;
@@ -207,7 +208,10 @@ var AmsifySuggestags;
               $(this).addClass('active');
               $(_self.selectors.sTagsInput).val($(this).text());
             }, function() {
-               $(this).removeClass('active');
+              $(this).removeClass('active');
+              if(!_self.settings.keepLastOnHoverTag) {
+                $(_self.selectors.sTagsInput).val('');
+              }
             });
           }
           $(this.selectors.listArea).find(this.classes.listItem).click(function(){


### PR DESCRIPTION
This will keep the last suggestion item in the input text field, even when moving away from the suggestion list. By default this is true.
Useful when showAllSuggestions is set to true and you wish to hide the suggestion list when clicking away from the input text field.