### PR TITLE
Allow addTag/removeTag to have an optional animate boolean

### DIFF
--- a/js/jquery.amsify.suggestags.js
+++ b/js/jquery.amsify.suggestags.js
@@ -504,7 +504,7 @@ var AmsifySuggestags;
 			return listHTML;
 		},
 
-		addTag : function(value) {
+		addTag : function(value, animate=true) {
 			if(!value) {
                 return;
             }
@@ -514,18 +514,18 @@ var AmsifySuggestags;
 				$item.addClass(this.settings.defaultTagClass);
 			}
 			if(this.settings.tagLimit != -1 && this.settings.tagLimit > 0 && this.tagNames.length >= this.settings.tagLimit) {
-				this.animateRemove($item, true);
+				this.animateRemove($item, animate);
 				this.flashItem(value);
 				return false;
 			}
 			var itemKey = this.getItemKey(value);
 			if(this.settings.whiteList && itemKey === -1) {
-				this.animateRemove($item, true);
+				this.animateRemove($item, animate);
 				this.flashItem(value);
 				return false;
 			}
 			if(this.isPresent(value)) {
-				this.animateRemove($item, true);
+				this.animateRemove($item, animate);
 				this.flashItem(value);
 			} else {
 				this.customStylings($item, itemKey);
@@ -600,12 +600,12 @@ var AmsifySuggestags;
             }
 		},
 
-		removeTag: function(value) {
+		removeTag: function(value, animate=true) {
 			var _self = this;
 			$findTags = $(this.selectors.sTagsArea).find('[data-val="'+value+'"]');
 			if($findTags.length) {
 				$findTags.each(function(){
-					_self.removeTagByItem(this, true);
+					_self.removeTagByItem(this, animate);
 				});
 			}
 		},


### PR DESCRIPTION
This change allows a JavaScript caller to disable the animation event on the addTag and removeTag.

In our usage, oftentimes, we'll have a hidden form that is prepopulated before being shown to the user.  As the form may be shown and hidden multiple times, before we display the form, we blank out any previous items in the field.

Our logic goes like this:
- Remove all items from the field
- Pre-populate form properly before view

If any of the items being removed are repopulated before the form is shown, then the animateRemove and animateAdd callbacks collide and cause the form to not display properly.  Disabling animation when we addTag and removeTag programmatically makes all of this go away.