### PR TITLE
Disable Flash If No Animate

### DIFF
--- a/js/jquery.amsify.suggestags.js
+++ b/js/jquery.amsify.suggestags.js
@@ -514,18 +514,24 @@ var AmsifySuggestags;
 			}
 			if(this.settings.tagLimit != -1 && this.settings.tagLimit > 0 && this.tagNames.length >= this.settings.tagLimit) {
 				this.animateRemove($item, animate);
-				this.flashItem(value);
+				if(animate) {
+					this.flashItem(value);
+				}
 				return false;
 			}
 			var itemKey = this.getItemKey(value);
 			if(this.settings.whiteList && itemKey === -1) {
 				this.animateRemove($item, animate);
-				this.flashItem(value);
+				if(animate) {
+					this.flashItem(value);
+				}
 				return false;
 			}
 			if(this.isPresent(value)) {
 				this.animateRemove($item, animate);
-				this.flashItem(value);
+				if(animate) {
+					this.flashItem(value);
+				}
 			} else {
 				this.customStylings($item, itemKey);
 				var dataVal = value;


### PR DESCRIPTION
If animation is disabled and tags are populated, sometimes the tag stays red due to collisions in the flash callback.  If tags are being added via with amsify hidden, there is no sense in flashing a hidden tag.

![image](https://user-images.githubusercontent.com/3707010/98403782-bb690480-2026-11eb-8a7e-576ad2492288.png)
