### PR TITLE
Dashspaces, trim trail/end space, and lowercase

### DIFF
--- a/examples/bootstrap/index.html
+++ b/examples/bootstrap/index.html
@@ -58,6 +58,11 @@
 		<div class="form-group">
 			<input type="text" class="form-control" name="anything" value="one,two,three,four,five,six"/>
 		</div>
+
+		<h4>Trim, Low Case, Add dashes</h4>
+		<div class="form-group">
+			<input type="text" class="form-control" name="new_types"/>
+		</div>
 	</div>
 	<div class="col-md-3"></div>
 </div>
@@ -98,12 +103,19 @@
 				$('input[name="anything"]').amsifySuggestags({
 					tagLimit: 5
 				});
+				$('input[name="new_types"]').amsifySuggestags({
+					trimValue: true,
+					dashspaces: true,
+					lowercase: true,
+					tagLimit: 4
+				});
 			</code>
 		</pre>
 	</div>
 </footer>
 <!-- -->
 <script type="text/javascript">
+	
 	$('input[name="country"]').amsifySuggestags();
 	$('input[name="color"]').amsifySuggestags({
 		suggestions: ['Black', 'White', 'Red', 'Blue', 'Green', 'Orange'],
@@ -156,6 +168,14 @@
 	$('input[name="anything"]').amsifySuggestags({
 		tagLimit: 5
 	});
+
+	$('input[name="new_types"]').amsifySuggestags({
+		trimValue: true,
+		dashspaces: true,
+		lowercase: true,
+		tagLimit: 4
+	});
+
 </script>
 </body>
 </html>

--- a/js/jquery.amsify.suggestags.js
+++ b/js/jquery.amsify.suggestags.js
@@ -893,5 +893,23 @@ var AmsifySuggestags;
 			amsifySuggestags._setMethod(method);
 			amsifySuggestags._init();
 		});
+	
+		
 	};
+
+	//get items as a function call -- over each of the selected class items.
+	// if div and items, then select div and find the class containing data-val
+	$.fn.get_items = function(arg){
+		arr_tags = [];
+		$.each($(this), function(){
+			arr_tags.push($(this).attr("data-val"));
+		});
+		if (arg === "items"){
+			return arr_tags;
+		}
+		else if(arg === "string"){
+			return arr_tags.join();
+		}
+	};
+
 }));

--- a/js/jquery.amsify.suggestags.js
+++ b/js/jquery.amsify.suggestags.js
@@ -30,9 +30,9 @@ var AmsifySuggestags;
 			afterAdd          : {},
 			afterRemove       : {},
 			//My changes
-            trimValue         : false,
-            dashspaces        : false,
-            lowercase         : false,
+			trimValue         : false,
+			dashspaces        : false,
+			lowercase         : false,
 			selectOnHover     : true,
 			triggerChange     : false,
 			noSuggestionMsg   : '',
@@ -510,22 +510,21 @@ var AmsifySuggestags;
 			if(!value) {
                 return;
 			}
-
 			// Trim value
 			if (typeof value === "string" && this.settings.trimValue) {
-                value = $.trim(value);
-            }
-
-            // lowercase and dash
-            if (typeof value === "string" && this.settings.lowercase && this.settings.dashspaces) {
-                value = value.replace(/\s+/g, '-').toLowerCase();
-            }
-            else if (typeof value === "string" && this.settings.lowercase){
-                value = value.toLowerCase();
-            }
-            else if (typeof value === "string" && this.settings.dashspaces){
-                value = value.replace(/\s+/g, '-');
-            }
+				value = $.trim(value);
+			}
+			
+			// lowercase and dash
+			if (typeof value === "string" && this.settings.lowercase && this.settings.dashspaces) {
+				value = value.replace(/\s+/g, '-').toLowerCase();
+			}
+			else if (typeof value === "string" && this.settings.lowercase){
+				value = value.toLowerCase();
+			}
+			else if (typeof value === "string" && this.settings.dashspaces){
+				value = value.replace(/\s+/g, '-');
+			}
 
 			var html = '<span class="'+this.classes.tagItem.substring(1)+'" data-val="'+value+'">'+this.getTag(value)+' '+this.setIcon()+'</span>';
 			$item    = $(html).insertBefore($(this.selectors.sTagsInput));

--- a/js/jquery.amsify.suggestags.js
+++ b/js/jquery.amsify.suggestags.js
@@ -29,6 +29,10 @@ var AmsifySuggestags;
 			whiteList         : false,
 			afterAdd          : {},
 			afterRemove       : {},
+			//My changes
+            trimValue         : false,
+            dashspaces        : false,
+            lowercase         : false,
 			selectOnHover     : true,
 			triggerChange     : false,
 			noSuggestionMsg   : '',
@@ -505,7 +509,24 @@ var AmsifySuggestags;
 		addTag : function(value, animate=true) {
 			if(!value) {
                 return;
+			}
+
+			// Trim value
+			if (typeof value === "string" && this.settings.trimValue) {
+                value = $.trim(value);
             }
+
+            // lowercase and dash
+            if (typeof value === "string" && this.settings.lowercase && this.settings.dashspaces) {
+                value = value.replace(/\s+/g, '-').toLowerCase();
+            }
+            else if (typeof value === "string" && this.settings.lowercase){
+                value = value.toLowerCase();
+            }
+            else if (typeof value === "string" && this.settings.dashspaces){
+                value = value.replace(/\s+/g, '-');
+            }
+
 			var html = '<span class="'+this.classes.tagItem.substring(1)+'" data-val="'+value+'">'+this.getTag(value)+' '+this.setIcon()+'</span>';
 			$item    = $(html).insertBefore($(this.selectors.sTagsInput));
 			if(this.settings.defaultTagClass) {


### PR DESCRIPTION
Added the features as setting to do the following:

Example: if the input tag is Flask SQL,
`dashspaces` when set to true --> Flask-SQL
`trimValue` set to true --> will remove trail/end spaces and keep the word intact.
`lowercase` set to true --> flask sql . And combining with (dashSpaces, lowercase set to true) will output as flask-sql.

Additionally, a method is written to obtain the tags either as a list or string.
An example is: `$(".amsify-select-tag").get_items("items") `--> will return the tags in a list. 