### PR TITLE
Fix removing item twice

### DIFF
--- a/js/jquery.amsify.suggestags.js
+++ b/js/jquery.amsify.suggestags.js
@@ -626,7 +626,7 @@ var AmsifySuggestags;
 
 		removeTag: function(value, animate=true) {
 			var _self = this;
-			$findTags = $(this.selectors.sTagsArea).find('[data-val="'+value+'"]');
+			$findTags = $(this.selectors.inputArea).find('[data-val="'+value+'"]');
 			if($findTags.length) {
 				$findTags.each(function(){
 					_self.removeTagByItem(this, animate);


### PR DESCRIPTION
Calling `removeTag` for one value might result in two values being removed (alghough one of them will remain visible and will only be removed internally).

In the `sTagsArea` zone there are two elements with the same `data-val`: the `<span class="amsify-select-tag>` containing the selected tag and the `<li class="amsify-list-item">` containing the suggested tag.

This means every time we call `removeTag`, the `removeTagByItem` function is called twice, and might remove extra items.

This bug only takes place when calling the `removeTag` function; clicking the icon to remove a tag works properly since it doesn't call this method.

Here's a possible fix. Please let me know whether this is the right way to fix it! :wink: